### PR TITLE
Update to ESM export syntax for gjs compatibility

### DIFF
--- a/src/timeframe.js
+++ b/src/timeframe.js
@@ -1,4 +1,4 @@
-var TimeFrame = class {
+export default class {
     constructor() {
       this.date = this.unixChecker(arguments);
       this.startDate = Date.now();
@@ -100,7 +100,3 @@ var TimeFrame = class {
     }
   }
 
-if (typeof module !== 'undefined')
-{
-  module.exports = TimeFrame
-}


### PR DESCRIPTION
Since gnome 45 shell extensions use ESM export syntax. The previous var TimeFrame declaration no longer works.

This is a first step intended to fix https://gitlab.com/todo.txt-gnome-shell-extension/todo-txt-gnome-shell-extension/-/issues/165. However, it also breaks `jest` upstream and may cause other issues for them. 